### PR TITLE
State adjectives go after the state name in French, Italian, and Spanish

### DIFF
--- a/Vic2ToHoI4/Source/HOI4World/HoI4Localisation.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4Localisation.cpp
@@ -627,7 +627,15 @@ void HoI4::Localisation::addStateLocalisationForLanguage(const State& hoi4State,
 			 vic2Localisations.getTextInLanguage(vic2State.getOwner() + "_ADJ", Vic2NameInLanguage.first);
 		if (possibleOwnerAdjective)
 		{
-			localisedName = *possibleOwnerAdjective + " " + Vic2NameInLanguage.second;
+			if ((Vic2NameInLanguage.first == "french") || (Vic2NameInLanguage.first == "spanish") ||
+				 (Vic2NameInLanguage.first == "italian"))
+			{
+				localisedName = Vic2NameInLanguage.second + " " + *possibleOwnerAdjective;
+			}
+			else
+			{
+				localisedName = *possibleOwnerAdjective + " " + Vic2NameInLanguage.second;
+			}
 		}
 	}
 	else if (hoi4State.isImpassable())


### PR DESCRIPTION
Part of #493 