### PR TITLE
Adjust VP values

### DIFF
--- a/Vic2ToHoI4/Source/HOI4World/HoI4Country.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4Country.cpp
@@ -299,9 +299,11 @@ void HoI4::Country::convertStrategies(const CountryMapper& countryMap, const Vic
 			conquerStrategies.push_back(newStrategy);
 		}
 	}
-	std::sort(conquerStrategies.begin(), conquerStrategies.end(), [](const HoI4::AIStrategy& a, const HoI4::AIStrategy& b) {
+	std::sort(conquerStrategies.begin(),
+		 conquerStrategies.end(),
+		 [](const HoI4::AIStrategy& a, const HoI4::AIStrategy& b) {
 			 return a.getValue() > b.getValue();
-	});
+		 });
 
 	for (const auto& srcStrategy: sourceCountry.getAI()->getStrategies())
 	{
@@ -1028,7 +1030,6 @@ const bool HoI4::Country::isEligibleEnemy(std::string target)
 		allies = faction->getLeader()->getAllies();
 		allies.insert(faction->getLeader()->getTag());
 	}
-	
+
 	return !allies.contains(target) && !puppets.contains(target) && target != puppetMaster;
 }
-

--- a/Vic2ToHoI4/Source/HOI4World/HoI4World.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4World.cpp
@@ -142,7 +142,7 @@ HoI4::World::World(const Vic2::World& sourceWorld,
 	addNeutrality(theConfiguration.getDebug());
 	addLeaders();
 	convertIdeologySupport();
-	states->convertCapitalVPs(countries, greatPowers, getStrongestCountryStrength());
+	states->convertCapitalVPs(countries, greatPowers);
 	states->convertAirBases(countries, greatPowers);
 	if (theConfiguration.getCreateFactions())
 	{
@@ -685,22 +685,6 @@ void HoI4::World::setupNavalTreaty()
 		hoi4Localisations->addDecisionLocalisation(strongestGpNavies->second + "_Naval_treaty_nation",
 			 "@" + strongestGpNavies->second + " [" + strongestGpNavies->second + ".GetName]");
 	}
-}
-
-
-double HoI4::World::getStrongestCountryStrength() const
-{
-	double greatestStrength = 0.0;
-	for (auto country: countries)
-	{
-		double currentStrength = country.second->getStrengthOverTime(1.0);
-		if (currentStrength > greatestStrength)
-		{
-			greatestStrength = currentStrength;
-		}
-	}
-
-	return greatestStrength;
 }
 
 

--- a/Vic2ToHoI4/Source/HOI4World/HoI4World.h
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4World.h
@@ -166,8 +166,6 @@ class World: commonItems::parser
 
 	void setupNavalTreaty();
 
-	double getStrongestCountryStrength() const;
-
 	void createFactions(const Configuration& theConfiguration);
 	void logFactionMember(std::ofstream& factionsLog, std::shared_ptr<HoI4::Country> member) const;
 	std::optional<std::string> returnSphereLeader(std::shared_ptr<HoI4::Country> possibleSphereling) const;

--- a/Vic2ToHoI4/Source/HOI4World/States/HoI4State.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/States/HoI4State.cpp
@@ -183,10 +183,9 @@ void HoI4::State::assignVP(int location)
 {
 	victoryPointPosition = location;
 
-	victoryPointValue = 1;
 	if (cores.contains(ownerTag))
 	{
-		victoryPointValue += 2;
+		victoryPointValue += 1;
 	}
 }
 

--- a/Vic2ToHoI4/Source/HOI4World/States/HoI4State.h
+++ b/Vic2ToHoI4/Source/HOI4World/States/HoI4State.h
@@ -50,6 +50,7 @@ class State
 			airbaseLevel = 10;
 	}
 	void addVictoryPointValue(int additionalValue) { victoryPointValue += additionalValue; }
+	void setVPValue(int value) { victoryPointValue = value; }
 	void setVPLocation(int province) { victoryPointPosition = province; }
 
 	void convertNavalBases(const std::map<int, int>& sourceNavalBases,

--- a/Vic2ToHoI4/Source/HOI4World/States/HoI4States.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/States/HoI4States.cpp
@@ -751,7 +751,7 @@ void HoI4::States::addGreatPowerVPs(const std::vector<std::shared_ptr<Country>>&
 				capitalState->second.setVPValue(40);
 			}
 		}
-		ranking++;
+		++ranking;
 	}
 }
 

--- a/Vic2ToHoI4/Source/HOI4World/States/HoI4States.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/States/HoI4States.cpp
@@ -771,7 +771,7 @@ void HoI4::States::addCapitalVictoryPoints(const std::map<std::string, std::shar
 	});
 
 	auto i = 0;
-	for (; i < 4; i++)
+	for (; i < 4 && i < tags.size(); i++)
 	{
 		auto country = countries.at(tags[i]);
 		if (auto capitalState = states.find(*country->getCapitalState()); capitalState != states.end())
@@ -779,7 +779,7 @@ void HoI4::States::addCapitalVictoryPoints(const std::map<std::string, std::shar
 			capitalState->second.setVPValue(30);
 		}
 	}
-	for (; i < 8; i++)
+	for (; i < 8 && i < tags.size(); i++)
 	{
 		auto country = countries.at(tags[i]);
 		if (auto capitalState = states.find(*country->getCapitalState()); capitalState != states.end())
@@ -787,7 +787,7 @@ void HoI4::States::addCapitalVictoryPoints(const std::map<std::string, std::shar
 			capitalState->second.setVPValue(25);
 		}
 	}
-	for (; i < 16; i++)
+	for (; i < 16 && i < tags.size(); i++)
 	{
 		auto country = countries.at(tags[i]);
 		if (auto capitalState = states.find(*country->getCapitalState()); capitalState != states.end())

--- a/Vic2ToHoI4/Source/HOI4World/States/HoI4States.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/States/HoI4States.cpp
@@ -701,7 +701,7 @@ void HoI4::States::convertCapitalVPs(const std::map<std::string, std::shared_ptr
 {
 	Log(LogLevel::Info) << "\tConverting capital VPs";
 
-	addStrengthVPs(countries);
+	addCapitalVictoryPoints(countries);
 	addGreatPowerVPs(greatPowers);
 }
 
@@ -756,7 +756,7 @@ void HoI4::States::addGreatPowerVPs(const std::vector<std::shared_ptr<Country>>&
 }
 
 
-void HoI4::States::addStrengthVPs(const std::map<std::string, std::shared_ptr<Country>>& countries)
+void HoI4::States::addCapitalVictoryPoints(const std::map<std::string, std::shared_ptr<Country>>& countries)
 {
 	std::vector<std::string> tags;
 	for (const auto& [tag, country]: countries)

--- a/Vic2ToHoI4/Source/HOI4World/States/HoI4States.h
+++ b/Vic2ToHoI4/Source/HOI4World/States/HoI4States.h
@@ -72,8 +72,7 @@ class States: commonItems::parser
 		 const CoastalProvinces& theCoastalProvinces,
 		 const Configuration& theConfiguration);
 	void convertCapitalVPs(const std::map<std::string, std::shared_ptr<Country>>& countries,
-		 const std::vector<std::shared_ptr<Country>>& greatPowers,
-		 double greatestStrength);
+		 const std::vector<std::shared_ptr<Country>>& greatPowers);
 	void addCapitalsToStates(const std::map<std::string, std::shared_ptr<Country>>& countries);
 	void giveProvinceControlToCountry(int provinceNum, const std::string& country);
 
@@ -147,10 +146,8 @@ class States: commonItems::parser
 	void addCapitalAirBases(const std::map<std::string, std::shared_ptr<Country>>& countries);
 	void addGreatPowerAirBases(const std::vector<std::shared_ptr<Country>>& greatPowers);
 
-	void addBasicCapitalVPs(const std::map<std::string, std::shared_ptr<Country>>& countries);
 	void addGreatPowerVPs(const std::vector<std::shared_ptr<Country>>& greatPowers);
-	void addStrengthVPs(const std::map<std::string, std::shared_ptr<Country>>& countries, double greatestStrength);
-	[[nodiscard]] static int calculateStrengthVPs(const Country& country, double greatestStrength);
+	void addStrengthVPs(const std::map<std::string, std::shared_ptr<Country>>& countries);
 
 	std::map<int, std::string> ownersMap;
 	std::map<int, std::set<std::pair<std::string, std::string>>> coresMap;

--- a/Vic2ToHoI4/Source/HOI4World/States/HoI4States.h
+++ b/Vic2ToHoI4/Source/HOI4World/States/HoI4States.h
@@ -147,7 +147,7 @@ class States: commonItems::parser
 	void addGreatPowerAirBases(const std::vector<std::shared_ptr<Country>>& greatPowers);
 
 	void addGreatPowerVPs(const std::vector<std::shared_ptr<Country>>& greatPowers);
-	void addStrengthVPs(const std::map<std::string, std::shared_ptr<Country>>& countries);
+	void addCapitalVictoryPoints(const std::map<std::string, std::shared_ptr<Country>>& countries);
 
 	std::map<int, std::string> ownersMap;
 	std::map<int, std::set<std::pair<std::string, std::string>>> coresMap;

--- a/Vic2ToHoI4/Source/OutHoi4/States/OutHoI4State.cpp
+++ b/Vic2ToHoI4/Source/OutHoi4/States/OutHoI4State.cpp
@@ -33,12 +33,12 @@ void HoI4::outputHoI4State(std::ostream& output, const State& theState, const bo
 	}
 	if (!theState.isImpassable())
 	{
-		if ((theState.getVpValue() > 0) && theState.getVPLocation())
+		if (theState.getVPLocation())
 		{
 			if (debugEnabled)
 			{
 				output << "\t\tvictory_points = {\n";
-				output << "\t\t\t" << *theState.getVPLocation() << " " << (theState.getVpValue() + 10) << "\n";
+				output << "\t\t\t" << *theState.getVPLocation() << " 10\n";
 				output << "\t\t}\n";
 				for (auto VP: theState.getDebugVPs())
 				{

--- a/Vic2ToHoI4Tests/HoI4WorldTests/States/HoI4StateTests.cpp
+++ b/Vic2ToHoI4Tests/HoI4WorldTests/States/HoI4StateTests.cpp
@@ -848,7 +848,7 @@ TEST(HoI4World_States_StateTests, DebugVpsAreOutput)
 	expectedOutput << "\thistory={\n";
 	expectedOutput << "\t\towner = TAG\n";
 	expectedOutput << "\t\tvictory_points = {\n";
-	expectedOutput << "\t\t\t12 11\n";
+	expectedOutput << "\t\t\t12 10\n";
 	expectedOutput << "\t\t}\n";
 	expectedOutput << "\t\tvictory_points = { 24 5\n";
 	expectedOutput << "\t}\n";


### PR DESCRIPTION
Fixes #326 

* No automatic VPs
* VPs added for owner core decreased
* Set high VP value for GP capitals
* Set VP values for capitals in decreasing power rank