### PR TITLE
Skip creating countries whose capital can't be set

### DIFF
--- a/Vic2ToHoI4/Source/HOI4World/HoI4Country.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4Country.cpp
@@ -29,7 +29,9 @@ HoI4::Country::Country(std::string tag,
 	 const Mappers::CountryMapper& countryMap,
 	 const Mappers::FlagsToIdeasMapper& flagsToIdeasMapper,
 	 Localisation& hoi4Localisations,
-	 const date& startDate):
+	 const date& startDate,
+	 const Mappers::ProvinceMapper& theProvinceMapper,
+	 const States& worldStates):
 	 tag(std::move(tag)),
 	 name(sourceCountry.getName("english")), adjective(sourceCountry.getAdjective("english")),
 	 oldTag(sourceCountry.getTag()), human(human = sourceCountry.isHuman()), threat(sourceCountry.getBadBoy() / 10.0),
@@ -39,6 +41,11 @@ HoI4::Country::Country(std::string tag,
 	 oldGovernment(sourceCountry.getGovernment()), upperHouseComposition(sourceCountry.getUpperHouseComposition()),
 	 lastElection(sourceCountry.getLastElection())
 {
+	determineCapitalFromVic2(theProvinceMapper, worldStates.getProvinceToStateIDMap(), worldStates.getStates());
+	if (!getCapitalState())
+	{
+		return;
+	}
 	determineFilename();
 
 	const auto& sourceColor = sourceCountry.getColor();

--- a/Vic2ToHoI4/Source/HOI4World/HoI4Country.h
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4Country.h
@@ -61,7 +61,9 @@ class Country
 		 const Mappers::CountryMapper& countryMap,
 		 const Mappers::FlagsToIdeasMapper& flagsToIdeasMapper,
 		 Localisation& hoi4Localisations,
-		 const date& startDate);
+		 const date& startDate,
+		 const Mappers::ProvinceMapper& theProvinceMapper,
+		 const States& worldStates);
 	explicit Country(const std::string& tag_,
 		 const std::shared_ptr<Country> owner,
 		 const std::string& region_,

--- a/Vic2ToHoI4/Source/HOI4World/HoI4World.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4World.cpp
@@ -101,17 +101,6 @@ HoI4::World::World(const Vic2::World& sourceWorld,
 	const auto theProvinces = importProvinces(theConfiguration);
 	theCoastalProvinces.init(*theMapData, theProvinces);
 	strategicRegions = StrategicRegions::Factory().importStrategicRegions(theConfiguration);
-	names = Names::Factory().getNames(theConfiguration);
-	graphicsMapper = Mappers::GraphicsMapper::Factory().importGraphicsMapper();
-	countryNameMapper = Mappers::CountryNameMapper::Factory().importCountryNameMapper();
-	casusBellis = Mappers::CasusBellisFactory{}.importCasusBellis();
-	convertCountries(sourceWorld, provinceMapper);
-	determineGreatPowers(sourceWorld);
-	governmentMapper = Mappers::GovernmentMapper::Factory().importGovernmentMapper();
-	ideologyMapper = Mappers::IdeologyMapper::Factory().importIdeologyMapper();
-	convertGovernments(sourceWorld, vic2Localisations, theConfiguration.getDebug());
-	ideologies = std::make_unique<Ideologies>(theConfiguration);
-	ideologies->identifyMajorIdeologies(greatPowers, countries, theConfiguration);
 	states = std::make_unique<States>(sourceWorld,
 		 *countryMap,
 		 theProvinces,
@@ -124,6 +113,17 @@ HoI4::World::World(const Vic2::World& sourceWorld,
 		 *hoi4Localisations,
 		 provinceMapper,
 		 theConfiguration);
+	names = Names::Factory().getNames(theConfiguration);
+	graphicsMapper = Mappers::GraphicsMapper::Factory().importGraphicsMapper();
+	countryNameMapper = Mappers::CountryNameMapper::Factory().importCountryNameMapper();
+	casusBellis = Mappers::CasusBellisFactory{}.importCasusBellis();
+	convertCountries(sourceWorld, provinceMapper);
+	determineGreatPowers(sourceWorld);
+	governmentMapper = Mappers::GovernmentMapper::Factory().importGovernmentMapper();
+	ideologyMapper = Mappers::IdeologyMapper::Factory().importIdeologyMapper();
+	convertGovernments(sourceWorld, vic2Localisations, theConfiguration.getDebug());
+	ideologies = std::make_unique<Ideologies>(theConfiguration);
+	ideologies->identifyMajorIdeologies(greatPowers, countries, theConfiguration);
 	convertWars(sourceWorld, provinceMapper);
 	supplyZones = new HoI4::SupplyZones(states->getDefaultStates(), theConfiguration);
 	buildings = new Buildings(*states, theCoastalProvinces, *theMapData, provinceDefinitions, theConfiguration);
@@ -296,8 +296,13 @@ void HoI4::World::convertCountry(const std::string& oldTag,
 			 *countryMap,
 			 flagsToIdeasMapper,
 			 *hoi4Localisations,
-			 *theDate);
-		countries.insert(make_pair(*possibleHoI4Tag, destCountry));
+			 *theDate,
+			 provinceMapper,
+			 *states);
+		if (destCountry->getCapitalState())
+		{
+			countries.insert(make_pair(*possibleHoI4Tag, destCountry));
+		}
 	}
 }
 


### PR DESCRIPTION
Without properly set capital, country files are not even output. They can be safely skipped while creating countries. This will further enable rooting out references to their tags in other countries' files, e.g. converted strategies.