### PR TITLE
Quick fix for collaboration governments' names

### DIFF
--- a/Vic2ToHoI4/Source/HOI4World/HoI4Localisation.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4Localisation.cpp
@@ -269,6 +269,15 @@ bool HoI4::Localisation::addNeutralLocalisation(const std::pair<const std::strin
 				 nameInLanguage.second,
 				 hoi4Suffix,
 				 articleRules);
+
+			// For collaboration governments using non-ideological keys
+			newKey = tags.second + vic2Suffix;
+			addLocalisation(newKey,
+				 nameInLanguage.first,
+				 existingLanguage->second,
+				 nameInLanguage.second,
+				 hoi4Suffix,
+				 articleRules);
 		}
 		return true;
 	}


### PR DESCRIPTION
Should probably be separated from "neutral" ideology in a future country localisation restructuring.