### PR TITLE
update clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,7 +16,9 @@ AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
 BinPackArguments: false
 BinPackParameters: false
-BreakBeforeBraces: Allman
+BraceWrapping:
+  BeforeLambdaBody: false
+BreakBeforeBraces: Custom
 BreakConstructorInitializers: AfterColon
 ColumnLimit: 120
 Cpp11BracedListStyle: true


### PR DESCRIPTION
Reason why new VS murders lambdas in autoformat is because they actually fixed the bug with allman where that didn't happen, but should have. Swapping to custom fixes this.
