### PR TITLE
Handle overlord flags with odd-number heights.

### DIFF
--- a/Vic2ToHoI4/Source/OutHoi4/OutFlags.cpp
+++ b/Vic2ToHoI4/Source/OutHoi4/OutFlags.cpp
@@ -292,7 +292,7 @@ std::optional<tga_image*> HoI4::createDominionFlag(const std::string& hoi4Suffix
 			const auto sourceHeight = (*ownerSourceFlag)->height;
 			const auto sourceWidth = (*ownerSourceFlag)->width;
 
-			const auto verticalStartLine = sizeY - (sourceHeight / 2);
+			const auto verticalStartLine = sizeY - ((sourceHeight + 1) / 2);
 			for (int y = 0; y < sourceHeight; y += 2)
 			{
 				for (int x = 0; x < sourceWidth; x += 2)


### PR DESCRIPTION
Fixes #1215, and probably #1216