### PR TITLE
Add neutrality and no-ideology to CountryNamesMappings

### DIFF
--- a/Vic2ToHoI4/Data_Files/configurables/CountryNamesMappings.txt
+++ b/Vic2ToHoI4/Data_Files/configurables/CountryNamesMappings.txt
@@ -13,3 +13,5 @@ name_mapping = { vic2_gov = proletarian_dictatorship hoi4_ideology = communism }
 name_mapping = { vic2_gov = bourgeois_dictatorship hoi4_ideology = radical }
 name_mapping = { vic2_gov = fascist_dictatorship hoi4_ideology = fascism }
 name_mapping = { vic2_gov = absolute_monarchy hoi4_ideology = absolutist }
+name_mapping = { vic2_gov = "" hoi4_ideology = neutrality }
+name_mapping = { vic2_gov = "" hoi4_ideology = "" }

--- a/Vic2ToHoI4/Source/HOI4World/HoI4Localisation.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4Localisation.cpp
@@ -501,7 +501,10 @@ void HoI4::Localisation::createUnrecognizedNationLocalisations(const std::string
 
 	const auto unrecognizedNameLocalisations = vic2Localisations.getTextInEachLanguage("unrecognized_name");
 	const auto unrecognizedAdjectiveLocalisations = vic2Localisations.getTextInEachLanguage("unrecognized_adjective");
-	for (const auto& ideology: majorIdeologies)
+	auto localisationIdeologies = majorIdeologies;
+	localisationIdeologies.insert("");
+
+	for (const auto& ideology: localisationIdeologies)
 	{
 		Vic2::LanguageToLocalisationMap localisationsForGovernment;
 		// if there is a pre-set localisation of the form 'unrecognized_<region>', use it


### PR DESCRIPTION
This got lost when splitting up the previous PR into commits