### PR TITLE
War Creator no longer creates branches with no targets

### DIFF
--- a/Vic2ToHoI4/Data_Files/configurables/converterFocuses.txt
+++ b/Vic2ToHoI4/Data_Files/configurables/converterFocuses.txt
@@ -2375,6 +2375,7 @@ focus = {
 	id = _anschluss_
 	icon = GFX_goal_anschluss
 	prerequisite = { focus = mil_march }
+	relative_position_id = mil_march
 	cost = 10
 	ai_will_do = {
 		factor = 10

--- a/Vic2ToHoI4/Data_Files/configurables/converterFocuses.txt
+++ b/Vic2ToHoI4/Data_Files/configurables/converterFocuses.txt
@@ -941,7 +941,7 @@ focus = {
 		navy_experience = 25
 	}
 	ai_will_do = {
-		factor = 0
+		factor = 10
 		modifier = {
 		}
 	}

--- a/Vic2ToHoI4/Source/HOI4World/HoI4FocusTree.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4FocusTree.cpp
@@ -1343,15 +1343,10 @@ void HoI4FocusTree::addFascistAnnexationBranch(std::shared_ptr<HoI4::Country> Ho
 	if (const auto& originalFocus = loadedFocuses.find("The_third_way"); originalFocus != loadedFocuses.end())
 	{
 		auto newFocus = originalFocus->second.makeCustomizedCopy(Home->getTag());
-		if (annexationTargets.size() > numSudetenTargets)
-		{
-			newFocus->xPos = nextFreeColumn + static_cast<int>(annexationTargets.size()) - 1;
-		}
-		else
-		{
-			newFocus->xPos = nextFreeColumn + static_cast<int>(numSudetenTargets) - 1;
-		}
+		const auto& maxWidth = static_cast<int>(std::max(annexationTargets.size(), numSudetenTargets));
+		newFocus->xPos = nextFreeColumn + maxWidth - 1;
 		newFocus->yPos = 0;
+		nextFreeColumn += 2 * maxWidth;
 		// FIXME
 		// Need to get Drift Defense to work
 		// in modified generic focus? (tk)
@@ -1377,6 +1372,7 @@ void HoI4FocusTree::addFascistAnnexationBranch(std::shared_ptr<HoI4::Country> Ho
 		throw std::runtime_error("Could not load focus mil_march");
 	}
 
+	int annexationFreeColumn = 1 - static_cast<int>(annexationTargets.size());
 	for (const auto& target: annexationTargets)
 	{
 		const auto& possibleAnnexationTargetCountryName = target->getName();
@@ -1411,15 +1407,15 @@ void HoI4FocusTree::addFascistAnnexationBranch(std::shared_ptr<HoI4::Country> Ho
 				newFocus->updateFocusElement(newFocus->available, "#DATE", "date > " + dateAvailable.toString() + "\n");
 			}
 			newFocus->updateFocusElement(newFocus->available, "$TARGET", targetTag);
-			newFocus->xPos = nextFreeColumn;
-			newFocus->yPos = 2;
+			newFocus->xPos = annexationFreeColumn;
+			newFocus->yPos = 1;
 			newFocus->updateFocusElement(newFocus->completionReward, "$TARGETNAME", annexationTargetCountryName);
 			newFocus->updateFocusElement(newFocus->completionReward, "$TARGET", targetTag);
 			newFocus->updateFocusElement(newFocus->completionReward,
 				 "$EVENTID",
 				 std::to_string(events.getCurrentNationFocusEventNum()));
 			focuses.push_back(newFocus);
-			nextFreeColumn += 2;
+			annexationFreeColumn += 2;
 
 			events.createAnnexEvent(*Home, *target);
 		}

--- a/Vic2ToHoI4/Source/HOI4World/HoI4FocusTree.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4FocusTree.cpp
@@ -830,7 +830,7 @@ void HoI4FocusTree::addAbsolutistEmpireNationalFocuses(std::shared_ptr<HoI4::Cou
 		newFocus->relativePositionId = "EmpireGlory" + homeTag;
 		newFocus->xPos = -1;
 		newFocus->yPos = 1;
-		if (targetColonies.empty())
+		if (targetColonies.empty() && !annexationTargets.empty())
 		{
 			newFocus->aiWillDo = "= { factor = 0 }";
 		}
@@ -847,7 +847,7 @@ void HoI4FocusTree::addAbsolutistEmpireNationalFocuses(std::shared_ptr<HoI4::Cou
 		newFocus->relativePositionId = "EmpireGlory" + homeTag;
 		newFocus->xPos = 1;
 		newFocus->yPos = 1;
-		if (annexationTargets.empty())
+		if (annexationTargets.empty() && !targetColonies.empty())
 		{
 			newFocus->aiWillDo = "= { factor = 0 }";
 		}

--- a/Vic2ToHoI4/Source/HOI4World/HoI4FocusTree.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4FocusTree.cpp
@@ -830,6 +830,10 @@ void HoI4FocusTree::addAbsolutistEmpireNationalFocuses(std::shared_ptr<HoI4::Cou
 		newFocus->relativePositionId = "EmpireGlory" + homeTag;
 		newFocus->xPos = -1;
 		newFocus->yPos = 1;
+		if (targetColonies.empty())
+		{
+			newFocus->aiWillDo = "= { factor = 0 }";
+		}
 		focuses.push_back(newFocus);
 	}
 	else
@@ -843,6 +847,10 @@ void HoI4FocusTree::addAbsolutistEmpireNationalFocuses(std::shared_ptr<HoI4::Cou
 		newFocus->relativePositionId = "EmpireGlory" + homeTag;
 		newFocus->xPos = 1;
 		newFocus->yPos = 1;
+		if (annexationTargets.empty())
+		{
+			newFocus->aiWillDo = "= { factor = 0 }";
+		}
 		focuses.push_back(newFocus);
 	}
 	else

--- a/Vic2ToHoI4/Source/HOI4World/HoI4FocusTree.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4FocusTree.cpp
@@ -1326,6 +1326,7 @@ void HoI4FocusTree::addCommunistWarBranch(std::shared_ptr<HoI4::Country> Home,
 
 void HoI4FocusTree::addFascistAnnexationBranch(std::shared_ptr<HoI4::Country> Home,
 	 const std::vector<std::shared_ptr<HoI4::Country>>& annexationTargets,
+	 const size_t numSudetenTargets,
 	 HoI4::Events& events,
 	 HoI4::Localisation& hoi4Localisations)
 {
@@ -1334,14 +1335,13 @@ void HoI4FocusTree::addFascistAnnexationBranch(std::shared_ptr<HoI4::Country> Ho
 	if (const auto& originalFocus = loadedFocuses.find("The_third_way"); originalFocus != loadedFocuses.end())
 	{
 		auto newFocus = originalFocus->second.makeCustomizedCopy(Home->getTag());
-		if (!annexationTargets.empty())
+		if (annexationTargets.size() > numSudetenTargets)
 		{
 			newFocus->xPos = nextFreeColumn + static_cast<int>(annexationTargets.size()) - 1;
 		}
 		else
 		{
-			newFocus->xPos = nextFreeColumn;
-			nextFreeColumn += 2;
+			newFocus->xPos = nextFreeColumn + static_cast<int>(numSudetenTargets) - 1;
 		}
 		newFocus->yPos = 0;
 		// FIXME

--- a/Vic2ToHoI4/Source/HOI4World/HoI4FocusTree.h
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4FocusTree.h
@@ -66,6 +66,7 @@ class HoI4FocusTree: commonItems::parser
 		 HoI4::Localisation& hoi4Localisations);
 	void addFascistAnnexationBranch(std::shared_ptr<HoI4::Country> Home,
 		 const std::vector<std::shared_ptr<HoI4::Country>>& annexationTargets,
+		 const size_t numSudetenTargets,
 		 HoI4::Events& events,
 		 HoI4::Localisation& hoi4Localisations);
 	void addFascistSudetenBranch(std::shared_ptr<HoI4::Country> Home,

--- a/Vic2ToHoI4/Source/HOI4World/WarCreator/HoI4WarCreator.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/WarCreator/HoI4WarCreator.cpp
@@ -910,10 +910,7 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::absolutistWarCreator
 
 	auto weakNeighbors = findWeakNeighbors(country, theMapData, provinceDefinitions);
 	auto weakColonies = findWeakColonies(country, theMapData, provinceDefinitions);
-	if (!weakNeighbors.empty() || !weakColonies.empty())
-	{
-		focusTree->addAbsolutistEmpireNationalFocuses(country, weakColonies, weakNeighbors, hoi4Localisations);
-	}
+	focusTree->addAbsolutistEmpireNationalFocuses(country, weakColonies, weakNeighbors, hoi4Localisations);
 
 	
 	if (auto greatPowerTargets = getGreatPowerTargets(country); !greatPowerTargets.empty())

--- a/Vic2ToHoI4/Source/HOI4World/WarCreator/HoI4WarCreator.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/WarCreator/HoI4WarCreator.cpp
@@ -422,7 +422,7 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::fascistWarMaker(std:
 	 const Configuration& theConfiguration)
 {
 	std::vector<std::shared_ptr<HoI4::Faction>> CountriesAtWar;
-	Log(LogLevel::Info) << "\t\tPicking targets for " + Leader->getTag();
+	Log(LogLevel::Info) << "\t\t\tPicking targets for " + Leader->getTag();
 	// too many lists, need to clean up
 	std::vector<std::shared_ptr<HoI4::Country>> Anschluss;
 	std::vector<std::shared_ptr<HoI4::Country>> Sudeten;
@@ -680,7 +680,7 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::communistWarCreator(
 {
 	std::vector<std::shared_ptr<HoI4::Faction>> CountriesAtWar;
 	// communism still needs great country war events
-	Log(LogLevel::Info) << "\t\tPicking targets for " + Leader->getTag();
+	Log(LogLevel::Info) << "\t\t\tPicking targets for " + Leader->getTag();
 	std::set<std::string> neighbors;
 	const auto& nearbyCountries = mapUtils.getNearbyCountries(Leader->getTag(), 400);
 	const auto& targets = Leader->getConquerStrategies();
@@ -906,7 +906,7 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::absolutistWarCreator
 	std::vector<std::shared_ptr<HoI4::Faction>> CountriesAtWar;
 	auto focusTree = genericFocusTree->makeCustomizedCopy(*country);
 
-	Log(LogLevel::Info) << "\t\tPicking targets for " + country->getTag();
+	Log(LogLevel::Info) << "\t\t\tPicking targets for " + country->getTag();
 
 	auto weakNeighbors = findWeakNeighbors(country, theMapData, provinceDefinitions);
 	auto weakColonies = findWeakColonies(country, theMapData, provinceDefinitions);

--- a/Vic2ToHoI4/Source/HOI4World/WarCreator/HoI4WarCreator.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/WarCreator/HoI4WarCreator.cpp
@@ -641,7 +641,7 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::fascistWarMaker(std:
 			 theWorld->getEvents(),
 			 hoi4Localisations);
 	}
-	
+
 	if (!sudetenTargets.empty() && !demandedStates.empty())
 	{
 		FocusTree->addFascistSudetenBranch(Leader,
@@ -912,7 +912,7 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::absolutistWarCreator
 	auto weakColonies = findWeakColonies(country, theMapData, provinceDefinitions);
 	focusTree->addAbsolutistEmpireNationalFocuses(country, weakColonies, weakNeighbors, hoi4Localisations);
 
-	
+
 	if (auto greatPowerTargets = getGreatPowerTargets(country); !greatPowerTargets.empty())
 	{
 		CountriesAtWar = addGreatPowerWars(country, *focusTree, greatPowerTargets, hoi4Localisations);

--- a/Vic2ToHoI4/Source/HOI4World/WarCreator/HoI4WarCreator.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/WarCreator/HoI4WarCreator.cpp
@@ -636,7 +636,11 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::fascistWarMaker(std:
 
 	if (!anschlussTargets.empty())
 	{
-		FocusTree->addFascistAnnexationBranch(Leader, anschlussTargets, theWorld->getEvents(), hoi4Localisations);
+		FocusTree->addFascistAnnexationBranch(Leader,
+			 anschlussTargets,
+			 sudetenTargets.size(),
+			 theWorld->getEvents(),
+			 hoi4Localisations);
 	}
 	
 	if (!sudetenTargets.empty() && !demandedStates.empty())

--- a/Vic2ToHoI4/Source/HOI4World/WarCreator/HoI4WarCreator.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/WarCreator/HoI4WarCreator.cpp
@@ -601,7 +601,6 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::fascistWarMaker(std:
 							auto newFaction = std::make_shared<HoI4::Faction>(greatPower, self);
 							greatPower->setFaction(newFaction);
 						}
-						theWorld->getEvents().createFactionEvents(*Leader, theWorld->getFactionNameMapper());
 					}
 					newAllies.push_back(greatPower);
 					++numAlliances;

--- a/Vic2ToHoI4/Source/HOI4World/WarCreator/HoI4WarCreator.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/WarCreator/HoI4WarCreator.cpp
@@ -422,7 +422,7 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::fascistWarMaker(std:
 	 const Configuration& theConfiguration)
 {
 	std::vector<std::shared_ptr<HoI4::Faction>> CountriesAtWar;
-	Log(LogLevel::Info) << "\t\t\tCalculating AI for " + Leader->getTag();
+	Log(LogLevel::Info) << "\t\tPicking targets for " + Leader->getTag();
 	// too many lists, need to clean up
 	std::vector<std::shared_ptr<HoI4::Country>> Anschluss;
 	std::vector<std::shared_ptr<HoI4::Country>> Sudeten;
@@ -510,8 +510,6 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::fascistWarMaker(std:
 	// gives us generic focus tree start
 	auto FocusTree = genericFocusTree->makeCustomizedCopy(*Leader);
 
-	FocusTree->addFascistAnnexationBranch(Leader, anschlussTargets, theWorld->getEvents(), hoi4Localisations);
-
 	std::vector<std::shared_ptr<HoI4::Country>> sudetenTargets;
 	for (auto target: Sudeten)
 	{
@@ -544,12 +542,6 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::fascistWarMaker(std:
 			demandedStates[target->getTag()] =
 				 mapUtils.sortStatesByDistance(borderStates, *leaderCapitalPosition, world->getStates());
 		}
-		FocusTree->addFascistSudetenBranch(Leader,
-			 anschlussTargets,
-			 sudetenTargets,
-			 demandedStates,
-			 theWorld->getEvents(),
-			 hoi4Localisations);
 	}
 
 	// events for allies
@@ -642,15 +634,36 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::fascistWarMaker(std:
 		}
 	}
 
-	FocusTree->addGPWarBranch(Leader,
-		 newAllies,
-		 GCTargets,
-		 "Fascist",
-		 theWorld->getEvents(),
-		 theWorld->getFactionNameMapper(),
-		 hoi4Localisations);
+	if (!anschlussTargets.empty())
+	{
+		FocusTree->addFascistAnnexationBranch(Leader, anschlussTargets, theWorld->getEvents(), hoi4Localisations);
+	}
+	
+	if (!sudetenTargets.empty() && !demandedStates.empty())
+	{
+		FocusTree->addFascistSudetenBranch(Leader,
+			 anschlussTargets,
+			 sudetenTargets,
+			 demandedStates,
+			 theWorld->getEvents(),
+			 hoi4Localisations);
+	}
 
-	Leader->giveNationalFocus(FocusTree);
+	if (!GCTargets.empty())
+	{
+		FocusTree->addGPWarBranch(Leader,
+			 newAllies,
+			 GCTargets,
+			 "Fascist",
+			 theWorld->getEvents(),
+			 theWorld->getFactionNameMapper(),
+			 hoi4Localisations);
+	}
+
+	if (FocusTree)
+	{
+		Leader->giveNationalFocus(FocusTree);
+	}
 	return CountriesAtWar;
 }
 
@@ -664,8 +677,7 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::communistWarCreator(
 {
 	std::vector<std::shared_ptr<HoI4::Faction>> CountriesAtWar;
 	// communism still needs great country war events
-	Log(LogLevel::Info) << "\t\t\tCalculating AI for " + Leader->getTag();
-	Log(LogLevel::Info) << "\t\t\tCalculating Neighbors for " + Leader->getTag();
+	Log(LogLevel::Info) << "\t\tPicking targets for " + Leader->getTag();
 	std::set<std::string> neighbors;
 	const auto& nearbyCountries = mapUtils.getNearbyCountries(Leader->getTag(), 400);
 	const auto& targets = Leader->getConquerStrategies();
@@ -817,16 +829,29 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::communistWarCreator(
 	}
 
 	auto FocusTree = genericFocusTree->makeCustomizedCopy(*Leader);
-	FocusTree->addCommunistCoupBranch(Leader, forcedtakeover, majorIdeologies, hoi4Localisations);
-	FocusTree->addCommunistWarBranch(Leader, TargetsByTech, theWorld->getEvents(), hoi4Localisations);
-	FocusTree->addGPWarBranch(Leader,
-		 newAllies,
-		 finalTargets,
-		 "Communist",
-		 theWorld->getEvents(),
-		 theWorld->getFactionNameMapper(),
-		 hoi4Localisations);
-	Leader->giveNationalFocus(FocusTree);
+	if (!forcedtakeover.empty())
+	{
+		FocusTree->addCommunistCoupBranch(Leader, forcedtakeover, majorIdeologies, hoi4Localisations);
+	}
+	if (!TargetsByTech.empty())
+	{
+		FocusTree->addCommunistWarBranch(Leader, TargetsByTech, theWorld->getEvents(), hoi4Localisations);
+	}
+	if (!newAllies.empty() && !finalTargets.empty())
+	{
+		FocusTree->addGPWarBranch(Leader,
+			 newAllies,
+			 finalTargets,
+			 "Communist",
+			 theWorld->getEvents(),
+			 theWorld->getFactionNameMapper(),
+			 hoi4Localisations);
+	}
+
+	if (FocusTree)
+	{
+		Leader->giveNationalFocus(FocusTree);
+	}
 
 	return CountriesAtWar;
 }
@@ -848,7 +873,6 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::democracyWarCreator(
 			double relationVal = relations->getRelations();
 			if (relationVal < 100 && GC->getGovernmentIdeology() != "democratic" && !Allies.contains(GC->getTag()))
 			{
-				CountriesAtWar.push_back(findFaction(Leader));
 				CountriesToContain.insert(std::make_pair(static_cast<int>(relationVal), GC));
 			}
 		}
@@ -857,11 +881,14 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::democracyWarCreator(
 	{
 		vCountriesToContain.push_back(country.second);
 	}
-	if (vCountriesToContain.size() > 0)
+	if (vCountriesToContain.empty())
 	{
-		FocusTree->addDemocracyNationalFocuses(Leader, vCountriesToContain, hoi4Localisations);
+		return CountriesAtWar;
 	}
 
+	CountriesAtWar.push_back(findFaction(Leader));
+
+	FocusTree->addDemocracyNationalFocuses(Leader, vCountriesToContain, hoi4Localisations);
 	Leader->giveNationalFocus(FocusTree);
 
 	return CountriesAtWar;
@@ -873,19 +900,29 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::absolutistWarCreator
 	 const Maps::ProvinceDefinitions& provinceDefinitions,
 	 HoI4::Localisation& hoi4Localisations)
 {
+	std::vector<std::shared_ptr<HoI4::Faction>> CountriesAtWar;
 	auto focusTree = genericFocusTree->makeCustomizedCopy(*country);
 
-	Log(LogLevel::Info) << "\t\t\tDoing neighbor calcs for " + country->getTag();
+	Log(LogLevel::Info) << "\t\tPicking targets for " + country->getTag();
 
 	auto weakNeighbors = findWeakNeighbors(country, theMapData, provinceDefinitions);
 	auto weakColonies = findWeakColonies(country, theMapData, provinceDefinitions);
-	focusTree->addAbsolutistEmpireNationalFocuses(country, weakColonies, weakNeighbors, hoi4Localisations);
+	if (!weakNeighbors.empty() || !weakColonies.empty())
+	{
+		focusTree->addAbsolutistEmpireNationalFocuses(country, weakColonies, weakNeighbors, hoi4Localisations);
+	}
 
-	auto greatPowerTargets = getGreatPowerTargets(country);
-	auto CountriesAtWar = addGreatPowerWars(country, *focusTree, greatPowerTargets, hoi4Localisations);
-	addTradeEvents(country, greatPowerTargets);
+	
+	if (auto greatPowerTargets = getGreatPowerTargets(country); !greatPowerTargets.empty())
+	{
+		CountriesAtWar = addGreatPowerWars(country, *focusTree, greatPowerTargets, hoi4Localisations);
+		addTradeEvents(country, greatPowerTargets);
+	}
 
-	country->giveNationalFocus(focusTree);
+	if (focusTree)
+	{
+		country->giveNationalFocus(focusTree);
+	}
 
 	return CountriesAtWar;
 }


### PR DESCRIPTION
- Fascist, Communist and Democratic War Creators will not create branches if there are no eligible targets to declare war on, thus enabling Reclaim Cores and Border Disputes branches
- Absolutist and Radical branches will be created regardless of targets, since there are a lot of other useful focuses
- Anschluss and Sudeten branches are now properly aligned Solves #1389
- AI will now go down the Strengthen Colonies branch, unless there are no eligible war targets but the Strengthen Home does