### PR TITLE
Fix for War Creator bug with factions

### DIFF
--- a/Vic2ToHoI4/Source/HOI4World/Diplomacy/Faction.h
+++ b/Vic2ToHoI4/Source/HOI4World/Diplomacy/Faction.h
@@ -20,7 +20,7 @@ class Faction
   public:
 	Faction(std::shared_ptr<Country> leader,
 		 std::vector<std::shared_ptr<Country>> members,
-		 std::optional<std::string> name = std::nullopt):
+		 std::optional<std::string> name):
 		 factionLeader(std::move(leader)),
 		 factionMembers(std::move(members)), factionName(name)
 	{

--- a/Vic2ToHoI4/Source/HOI4World/WarCreator/HoI4WarCreator.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/WarCreator/HoI4WarCreator.cpp
@@ -398,7 +398,11 @@ std::shared_ptr<HoI4::Faction> HoI4WarCreator::findFaction(std::shared_ptr<HoI4:
 
 	std::vector<std::shared_ptr<HoI4::Country>> myself;
 	myself.push_back(CheckingCountry);
-	return std::make_shared<HoI4::Faction>(CheckingCountry, myself);
+	return std::make_shared<HoI4::Faction>(CheckingCountry,
+		 myself,
+		 theWorld->getFactionNameMapper().getFactionName(CheckingCountry->getGovernmentIdeology(),
+			  CheckingCountry->getPrimaryCulture(),
+			  CheckingCountry->getPrimaryCultureGroup()));
 }
 
 
@@ -552,7 +556,11 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::fascistWarMaker(std:
 		{
 			std::vector<std::shared_ptr<HoI4::Country>> self;
 			self.push_back(Leader);
-			auto newFaction = std::make_shared<HoI4::Faction>(Leader, self);
+			auto newFaction = std::make_shared<HoI4::Faction>(Leader,
+				 self,
+				 theWorld->getFactionNameMapper().getFactionName(Leader->getGovernmentIdeology(),
+					  Leader->getPrimaryCulture(),
+					  Leader->getPrimaryCultureGroup()));
 			Leader->setFaction(newFaction);
 		}
 	}

--- a/Vic2ToHoI4/Source/HOI4World/WarCreator/HoI4WarCreator.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/WarCreator/HoI4WarCreator.cpp
@@ -548,7 +548,7 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::fascistWarMaker(std:
 	auto newAllies = GetMorePossibleAllies(Leader);
 	if (theConfiguration.getCreateFactions())
 	{
-		if (newAllies.size() > 0 && Leader->isInFaction())
+		if (newAllies.size() > 0 && Leader->isInFaction() && Leader->getFaction()->getLeader() != Leader)
 		{
 			std::vector<std::shared_ptr<HoI4::Country>> self;
 			self.push_back(Leader);
@@ -591,16 +591,6 @@ std::vector<std::shared_ptr<HoI4::Faction>> HoI4WarCreator::fascistWarMaker(std:
 					if (theConfiguration.getDebug())
 					{
 						AILog << "\t" << Leader->getTag() << " can attempt to ally " << greatPower->getTag() << "\n";
-					}
-					if (theConfiguration.getCreateFactions())
-					{
-						if (greatPower->isInFaction())
-						{
-							std::vector<std::shared_ptr<HoI4::Country>> self;
-							self.push_back(greatPower);
-							auto newFaction = std::make_shared<HoI4::Faction>(greatPower, self);
-							greatPower->setFaction(newFaction);
-						}
 					}
 					newAllies.push_back(greatPower);
 					++numAlliances;


### PR DESCRIPTION
- Fascist War Maker will no longer knock the country out of its faction and create a new faction if the country was already the faction leader
- WarCreator uses FactionNameMapper when instantiating Faction - Fixes #1374 