### PR TITLE
Navies are not created for countries with no naval bases

### DIFF
--- a/Vic2ToHoI4/Data_Files/configurables/Historical Project Mod 0.4.6_province_mappings.txt
+++ b/Vic2ToHoI4/Data_Files/configurables/Historical Project Mod 0.4.6_province_mappings.txt
@@ -1577,7 +1577,7 @@
 	link = { vic2 = 767 hoi4 = 596 hoi4 = 3654 hoi4 = 665 hoi4 = 6672 } # Maribor -> Velenje, Celje, Maribor, Murksa Sobota
 	link = { vic2 = 774 hoi4 = 11901 hoi4 = 591 hoi4 = 6611 hoi4 = 984 } # Senj -> Gospic, Senj, Plitvicka Jezera, Korenica
 	link = { vic2 = 773 hoi4 = 3601 hoi4 = 11564 } # Karlovac -> Ogulin, Rijeka
-	link = { vic2 = 780 hoi4 = 3924 hoi4 = 3974 } # Split -> Split, Knin
+	link = { vic2 = 780 hoi4 = 3924 hoi4 = 3974 hoi4 = 11816 } # Split -> Split, Knin, Metkovic
 	link = { vic2 = 782 hoi4 = 6889 hoi4 = 3868 } # Dubrovnik -> Dubrovnik, Hvar
 	link = { vic2 = 771 hoi4 = 11581 hoi4 = 3592 } # Zagreb -> Zagreb, Karlovac
 	link = { vic2 = 775 hoi4 = 9611 } # Varadzin -> Varaždin
@@ -1590,7 +1590,7 @@
 	link = { vic2 = 785 hoi4 = 6983 hoi4 = 9588 hoi4 = 6619 hoi4 = 11572 hoi4 = 9591 } # Banja Luka -> Banja Luka, Derventa, Prijedor, Teslic, Doboj
 	link = { vic2 = 786 hoi4 = 6799 hoi4 = 11574 hoi4 = 606 } # Tuzla -> Tuzla, Brcko, Bijeljina
 	link = { vic2 = 789 hoi4 = 6957 hoi4 = 6942 } # Livno -> Posušje, Mostar
-	link = { vic2 = 788 hoi4 = 9894 hoi4 = 11845 hoi4 = 11816 } # Mostar -> Capljina, Trebinje, Metkovic
+	link = { vic2 = 788 hoi4 = 9894 hoi4 = 11845 } # Mostar -> Capljina, Trebinje
 	link = { vic2 = 783 hoi4 = 11899 hoi4 = 11872 hoi4 = 9922 } # Sarajevo -> Sarajevo, Zenica, Travnik
 	link = { vic2 = 787 hoi4 = 11741 hoi4 = 953 hoi4 = 982 } # Foca -> Bratunac, Foca, Višegrad
 	link = { vic2 = 2569 hoi4 = 11858 } # Niksic -> Nikšic

--- a/Vic2ToHoI4/Source/HOI4World/HoI4Country.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4Country.cpp
@@ -1201,16 +1201,19 @@ void HoI4::Country::convertNavies(const UnitMappings& unitMap,
 		}
 	}
 
-	theNavies = std::make_unique<Navies>(oldArmies,
-		 backupNavalLocation,
-		 unitMap,
-		 mtgUnitMap,
-		 *theShipVariants,
-		 provinceToStateIDMap,
-		 allStates,
-		 tag,
-		 provinceDefinitions,
-		 provinceMapper);
+	if (backupNavalLocation != 0)
+	{
+		theNavies = std::make_unique<Navies>(oldArmies,
+			 backupNavalLocation,
+			 unitMap,
+			 mtgUnitMap,
+			 *theShipVariants,
+			 provinceToStateIDMap,
+			 allStates,
+			 tag,
+			 provinceDefinitions,
+			 provinceMapper);
+	}
 
 	navyNames.addLegacyShipTypeNames(LegacyShipTypeNames{"submarine", "Submarine", getShipNames("frigate")});
 	navyNames.addLegacyShipTypeNames(LegacyShipTypeNames{"carrier", "Carrier", getShipNames("monitor")});
@@ -1601,6 +1604,10 @@ double HoI4::Country::getMilitaryStrength()
 float HoI4::Country::getNavalStrength() const
 {
 	auto navalStrength = 0.0f;
+	if (!theNavies)
+	{
+		return navalStrength;
+	}
 
 	for (const auto& navy: theNavies->getMtgNavies())
 	{
@@ -1725,4 +1732,17 @@ void HoI4::Country::addProvincesToHomeArea(int provinceId,
 void HoI4::Country::addTankDesigns(const PossibleTankDesigns& possibleDesigns)
 {
 	tankDesigns = std::make_unique<TankDesigns>(possibleDesigns, *theTechnologies);
+}
+
+
+std::optional<HoI4::Navies> HoI4::Country::getNavies() const
+{
+	if (theNavies)
+	{
+		return std::make_optional(*theNavies);
+	}
+	else
+	{
+		return std::nullopt;
+	}
 }

--- a/Vic2ToHoI4/Source/HOI4World/HoI4Country.h
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4Country.h
@@ -246,7 +246,7 @@ class Country
 	[[nodiscard]] const auto& getDivisionLocations() const { return theArmy.getDivisionLocations(); }
 	[[nodiscard]] const TankDesigns& getTankDesigns() const { return *tankDesigns; }
 	[[nodiscard]] const ShipVariants& getTheShipVariants() const { return *theShipVariants; }
-	[[nodiscard]] const Navies& getNavies() const { return *theNavies; }
+	[[nodiscard]] std::optional<Navies> getNavies() const;
 	[[nodiscard]] const auto& getNavyNames() const { return navyNames; }
 	[[nodiscard]] int getConvoys() const { return convoys; }
 	[[nodiscard]] auto getTrainsMultiplier() const { return trainsMultiplier; }

--- a/Vic2ToHoI4/Source/OutHoi4/OutHoi4Country.cpp
+++ b/Vic2ToHoI4/Source/OutHoi4/OutHoi4Country.cpp
@@ -1324,14 +1324,16 @@ void outputOOB(const std::vector<HoI4::DivisionTemplateType>& divisionTemplates,
 	}
 	output.close();
 
-	auto& navies = theCountry.getNavies();
-	std::ofstream legacyNavy(
-		 "output/" + theConfiguration.getOutputName() + "/history/units/" + tag + "_1936_naval_legacy.txt");
-	outputLegacyNavies(navies, *technologies, tag, legacyNavy);
+	if (const auto& navies = theCountry.getNavies(); navies)
+	{
+		std::ofstream legacyNavy(
+			 "output/" + theConfiguration.getOutputName() + "/history/units/" + tag + "_1936_naval_legacy.txt");
+		outputLegacyNavies(*navies, *technologies, tag, legacyNavy);
 
-	std::ofstream mtgNavy(
-		 "output/" + theConfiguration.getOutputName() + "/history/units/" + tag + "_1936_naval_mtg.txt");
-	outputMtgNavies(navies, *technologies, tag, mtgNavy);
+		std::ofstream mtgNavy(
+			 "output/" + theConfiguration.getOutputName() + "/history/units/" + tag + "_1936_naval_mtg.txt");
+		outputMtgNavies(*navies, *technologies, tag, mtgNavy);
+	}
 }
 
 


### PR DESCRIPTION
Fixes #1404 
Fixes #1406 - backup location is already searched from all ports, so if it's 0 that means no ports are owned, thus delete navy