### PR TITLE
Partial states held by same tag merge (#1274)

### DIFF
--- a/Vic2ToHoI4/Data_Files/ReadMe.txt
+++ b/Vic2ToHoI4/Data_Files/ReadMe.txt
@@ -52,6 +52,7 @@ RaduM84			- Programming, Data Files
 King_of_Men		- Programming, Analysis
 icalamesa		- Programming
 PheonixScale		- Programming
+Gawquon			- Programming
 Italianajt		- Analysis, Data Files, QA
 Ordinary_Kraut		- Analysis, Data Files
 DasGuntLord01		- Analysis

--- a/Vic2ToHoI4/Source/V2World/World/WorldFactory.cpp
+++ b/Vic2ToHoI4/Source/V2World/World/WorldFactory.cpp
@@ -101,6 +101,7 @@ std::unique_ptr<Vic2::World> Vic2::World::Factory::importWorld(const Configurati
 	determineEmployedWorkers();
 	overallMergeNations(theConfiguration.getDebug());
 	removeEmptyNations();
+	consolidatePartialStates();
 	addWarsToCountries(wars);
 	setLocalisations(*world->theLocalisations);
 	checkAllProvincesMapped(provinceMapper);
@@ -284,6 +285,13 @@ void Vic2::World::Factory::removeEmptyNations()
 			++country;
 		}
 	}
+}
+
+
+void Vic2::World::Factory::consolidatePartialStates()
+{
+	for (auto& country: world->countries | std::views::values)
+		country.mergeStates(*world->theStateDefinitions);
 }
 
 

--- a/Vic2ToHoI4/Source/V2World/World/WorldFactory.cpp
+++ b/Vic2ToHoI4/Source/V2World/World/WorldFactory.cpp
@@ -291,7 +291,9 @@ void Vic2::World::Factory::removeEmptyNations()
 void Vic2::World::Factory::consolidatePartialStates()
 {
 	for (auto& country: world->countries | std::views::values)
+	{
 		country.mergeStates(*world->theStateDefinitions);
+	}
 }
 
 

--- a/Vic2ToHoI4/Source/V2World/World/WorldFactory.h
+++ b/Vic2ToHoI4/Source/V2World/World/WorldFactory.h
@@ -39,6 +39,7 @@ class World::Factory: commonItems::parser
 		 removeCoresOptions option) const;
 	void determineEmployedWorkers();
 	void removeEmptyNations();
+	void consolidatePartialStates();
 	void addWarsToCountries(const std::vector<War>& wars);
 	void overallMergeNations(bool debug);
 	void mergeNations(const std::string& masterTag, const std::vector<std::string>& slaveTags, bool debug);


### PR DESCRIPTION
Solves #1274. A function that solves this is already implemented for nation-merging in Vic2::Country. Just called it for every country after all other country processing was done in the WorldFactory.
```
void Vic2::Country::mergeStates(const StateDefinitions& stateDefinitions)
{
	for (auto state = states.begin(); state != states.end(); ++state)
	{
		if (!state->isPartialState())
		{
			continue;
		}

		auto state2 = state;
		++state2;
		while (state2 != states.end())
		{
			if (state->getStateID() != state2->getStateID())
			{
				++state2;
				continue;
			}

			state->eatState(*state2, stateDefinitions);
			state2 = states.erase(state2);
		}
	}
}
```
![InkedNo Aqtau](https://user-images.githubusercontent.com/71318452/160264887-2e77c1d5-b5b5-43b9-85f0-aada04f15c9e.jpg)