### PR TITLE
Puppets don't get called to war from country history files

### DIFF
--- a/src/HOI4World/Diplomacy/HoI4War.cpp
+++ b/src/HOI4World/Diplomacy/HoI4War.cpp
@@ -1,11 +1,10 @@
 #include "HoI4War.h"
-#include "HOI4World/HoI4Country.h"
 #include "Log.h"
 
 
 
 HoI4::War::War(const Vic2::War& sourceWar,
-	 const std::map<std::string, std::shared_ptr<HoI4::Country>>& countries,
+	 const std::set<std::string>& independentCountries,
 	 const Mappers::CountryMapper& countryMapper,
 	 const Mappers::CasusBellis& casusBellis,
 	 const Mappers::ProvinceMapper& provinceMapper,
@@ -33,8 +32,7 @@ HoI4::War::War(const Vic2::War& sourceWar,
 			Log(LogLevel::Warning) << "Could not map " << defender << ", defending in a war";
 			continue;
 		}
-		if (const auto& defCountry = countries.find(*possibleDefender);
-			 defCountry != countries.end() && !defCountry->second->getPuppetMaster())
+		if (independentCountries.contains(*possibleDefender))
 		{
 			extraDefenders.insert(*possibleDefender);
 		}
@@ -62,8 +60,7 @@ HoI4::War::War(const Vic2::War& sourceWar,
 			Log(LogLevel::Warning) << "Could not map " << attacker << ", attacking in a war";
 			continue;
 		}
-		if (const auto& attCountry = countries.find(*possibleAttacker);
-			 attCountry != countries.end() && !attCountry->second->getPuppetMaster())
+		if (independentCountries.contains(*possibleAttacker))
 		{
 			extraAttackers.insert(*possibleAttacker);
 		}

--- a/src/HOI4World/Diplomacy/HoI4War.h
+++ b/src/HOI4World/Diplomacy/HoI4War.h
@@ -16,10 +16,14 @@
 namespace HoI4
 {
 
+class Country;
+
+
 class War
 {
   public:
 	War(const Vic2::War& sourceWar,
+		 const std::map<std::string, std::shared_ptr<HoI4::Country>>& countries,
 		 const Mappers::CountryMapper& countryMapper,
 		 const Mappers::CasusBellis& casusBellis,
 		 const Mappers::ProvinceMapper& provinceMapper,

--- a/src/HOI4World/Diplomacy/HoI4War.h
+++ b/src/HOI4World/Diplomacy/HoI4War.h
@@ -16,14 +16,11 @@
 namespace HoI4
 {
 
-class Country;
-
-
 class War
 {
   public:
 	War(const Vic2::War& sourceWar,
-		 const std::map<std::string, std::shared_ptr<HoI4::Country>>& countries,
+		 const std::set<std::string>& independentCountries,
 		 const Mappers::CountryMapper& countryMapper,
 		 const Mappers::CasusBellis& casusBellis,
 		 const Mappers::ProvinceMapper& provinceMapper,

--- a/src/HOI4World/HoI4Country.cpp
+++ b/src/HOI4World/HoI4Country.cpp
@@ -754,6 +754,7 @@ void HoI4::Country::convertStrategies(const Mappers::CountryMapper& countryMap,
 
 
 void HoI4::Country::convertWars(const Vic2::Country& theSourceCountry,
+	 const std::map<std::string, std::shared_ptr<HoI4::Country>>& countries,
 	 const Mappers::CountryMapper& countryMap,
 	 const Mappers::CasusBellis& casusBellis,
 	 const Mappers::ProvinceMapper& provinceMapper,
@@ -761,7 +762,7 @@ void HoI4::Country::convertWars(const Vic2::Country& theSourceCountry,
 {
 	for (const auto& sourceWar: theSourceCountry.getWars())
 	{
-		War theWar(sourceWar, countryMap, casusBellis, provinceMapper, provinceToStateIDMap);
+		War theWar(sourceWar, countries, countryMap, casusBellis, provinceMapper, provinceToStateIDMap);
 		wars.push_back(theWar);
 	}
 }

--- a/src/HOI4World/HoI4Country.cpp
+++ b/src/HOI4World/HoI4Country.cpp
@@ -754,7 +754,7 @@ void HoI4::Country::convertStrategies(const Mappers::CountryMapper& countryMap,
 
 
 void HoI4::Country::convertWars(const Vic2::Country& theSourceCountry,
-	 const std::map<std::string, std::shared_ptr<HoI4::Country>>& countries,
+	 const std::set<std::string>& independentCountries,
 	 const Mappers::CountryMapper& countryMap,
 	 const Mappers::CasusBellis& casusBellis,
 	 const Mappers::ProvinceMapper& provinceMapper,
@@ -762,7 +762,7 @@ void HoI4::Country::convertWars(const Vic2::Country& theSourceCountry,
 {
 	for (const auto& sourceWar: theSourceCountry.getWars())
 	{
-		War theWar(sourceWar, countries, countryMap, casusBellis, provinceMapper, provinceToStateIDMap);
+		War theWar(sourceWar, independentCountries, countryMap, casusBellis, provinceMapper, provinceToStateIDMap);
 		wars.push_back(theWar);
 	}
 }

--- a/src/HOI4World/HoI4Country.h
+++ b/src/HOI4World/HoI4Country.h
@@ -299,7 +299,7 @@ class Country
 	[[nodiscard]] const bool isEligibleEnemy(std::string target) const;
 
 	void convertWars(const Vic2::Country& sourceCountry,
-		 const std::map<std::string, std::shared_ptr<HoI4::Country>>& countries,
+		 const std::set<std::string>& independentCountries,
 		 const Mappers::CountryMapper& countryMap,
 		 const Mappers::CasusBellis& casusBellis,
 		 const Mappers::ProvinceMapper& provinceMapper,

--- a/src/HOI4World/HoI4Country.h
+++ b/src/HOI4World/HoI4Country.h
@@ -299,6 +299,7 @@ class Country
 	[[nodiscard]] const bool isEligibleEnemy(std::string target) const;
 
 	void convertWars(const Vic2::Country& sourceCountry,
+		 const std::map<std::string, std::shared_ptr<HoI4::Country>>& countries,
 		 const Mappers::CountryMapper& countryMap,
 		 const Mappers::CasusBellis& casusBellis,
 		 const Mappers::ProvinceMapper& provinceMapper,

--- a/src/HOI4World/HoI4World.cpp
+++ b/src/HOI4World/HoI4World.cpp
@@ -147,7 +147,6 @@ HoI4::World::World(const Vic2::World& sourceWorld,
 	ideologies->identifyMajorIdeologies(greatPowers, countries, theConfiguration);
 	setTrainMultipliers();
 	Log(LogLevel::Progress) << "40%";
-	convertWars(sourceWorld, provinceMapper);
 	supplyZones = new HoI4::SupplyZones(states->getDefaultStates(), theConfiguration);
 	buildings = new Buildings(*states, theCoastalProvinces, *theMapData, theConfiguration);
 	railways_ = std::make_unique<Railways>(sourceWorld.getProvinces(),
@@ -175,6 +174,7 @@ HoI4::World::World(const Vic2::World& sourceWorld,
 	convertIndustry(theConfiguration);
 	addProvincesToHomeAreas();
 	convertDiplomacy(sourceWorld);
+	convertWars(sourceWorld, provinceMapper);
 	addDominions(countryMapperFactory);
 	addUnrecognizedNations(countryMapperFactory, provinceMapper, sourceWorld);
 	states->addCoresToCorelessStates(sourceWorld.getCountries(),
@@ -1104,6 +1104,7 @@ void HoI4::World::convertWars(const Vic2::World& sourceWorld, const Mappers::Pro
 		}
 
 		country->second->convertWars(sourceCountry,
+			 countries,
 			 *countryMap,
 			 *casusBellis,
 			 provinceMapper,

--- a/src/HOI4World/HoI4World.cpp
+++ b/src/HOI4World/HoI4World.cpp
@@ -1103,8 +1103,16 @@ void HoI4::World::convertWars(const Vic2::World& sourceWorld, const Mappers::Pro
 			continue;
 		}
 
+		std::set<std::string> independentCountries;
+		for (const auto& [tag, country]: countries)
+		{
+			if (!country->getPuppetMaster())
+			{
+				independentCountries.insert(tag);
+			}
+		}
 		country->second->convertWars(sourceCountry,
-			 countries,
+			 independentCountries,
 			 *countryMap,
 			 *casusBellis,
 			 provinceMapper,


### PR DESCRIPTION
Instead, HoI4 handles this internally - all puppets join ongoing wars at the start.