### PR TITLE
Contiguous land is assigned to a single dominion

### DIFF
--- a/src/HOI4World/HoI4Country.cpp
+++ b/src/HOI4World/HoI4Country.cpp
@@ -1699,10 +1699,11 @@ std::optional<std::string> HoI4::Country::getDominionTag(const std::string& regi
 }
 
 
-void HoI4::Country::determineDominionAreas(const std::unique_ptr<Maps::MapData>& theMapData,
+std::vector<std::set<int>> HoI4::Country::getDominionAreas(const std::unique_ptr<Maps::MapData>& theMapData,
 	 const std::map<int, HoI4::State>& allStates,
 	 const std::map<int, int>& provinceToStateIdMap)
 {
+	std::vector<std::set<int>> dominionAreas;
 	std::set<int> area;
 
 	// Provinces with land connection to capital take the 0 index in dominionAreas vector
@@ -1722,7 +1723,7 @@ void HoI4::Country::determineDominionAreas(const std::unique_ptr<Maps::MapData>&
 		// Check every province in state to ensure that island provinces are added properly
 		for (const auto& province: state->second.getProvinces())
 		{
-			if (isProvinceInDominionArea(province))
+			if (isProvinceInDominionArea(province, dominionAreas))
 			{
 				continue;
 			}
@@ -1730,6 +1731,7 @@ void HoI4::Country::determineDominionAreas(const std::unique_ptr<Maps::MapData>&
 		}
 		dominionAreas.push_back(area);
 	}
+	return dominionAreas;
 }
 
 
@@ -1764,7 +1766,7 @@ void HoI4::Country::addProvincesToArea(int province,
 }
 
 
-bool HoI4::Country::isProvinceInDominionArea(int province)
+bool HoI4::Country::isProvinceInDominionArea(int province, const std::vector<std::set<int>>& dominionAreas)
 {
 	for (const auto& area: dominionAreas)
 	{

--- a/src/HOI4World/HoI4Country.cpp
+++ b/src/HOI4World/HoI4Country.cpp
@@ -1716,17 +1716,15 @@ void HoI4::Country::classifyProvincesByAreas(const std::unique_ptr<Maps::MapData
 		{
 			continue;
 		}
-		const auto& provinces = state->second.getProvinces();
-		if (provinces.empty())
-		{
-			continue;
-		}
-		if (isProvinceAssignedToArea(*provinces.begin()))
-		{
-			continue;
-		}
 		provincesInArea.clear();
-		addProvincesToHomeArea(*provinces.begin(), provincesInArea, theMapData, allStates, provinceToStateIdMap);
+		for (const auto& province: state->second.getProvinces())
+		{
+			if (isProvinceAssignedToArea(province))
+			{
+				continue;
+			}
+			addProvincesToHomeArea(province, provincesInArea, theMapData, allStates, provinceToStateIdMap);
+		}
 		homeAreaProvinces.push_back(provincesInArea);
 	}
 }

--- a/src/HOI4World/HoI4Country.h
+++ b/src/HOI4World/HoI4Country.h
@@ -153,10 +153,15 @@ class Country
 
 	void addUnbuiltCanal(const std::string& unbuiltCanal) { unbuiltCanals.push_back(unbuiltCanal); }
 
-	void addProvincesToHomeArea(int provinceId,
-		 const std::unique_ptr<Maps::MapData>& theMapData,
-		 const std::map<int, HoI4::State>& states,
+	void classifyProvincesByAreas(const std::unique_ptr<Maps::MapData>& theMapData,
+		 const std::map<int, HoI4::State>& allStates,
 		 const std::map<int, int>& provinceToStateIdMap);
+	void addProvincesToHomeArea(int provinceId,
+		 std::set<int>& provincesInArea,
+		 const std::unique_ptr<Maps::MapData>& theMapData,
+		 const std::map<int, HoI4::State>& allStates,
+		 const std::map<int, int>& provinceToStateIdMap);
+	bool isProvinceAssignedToArea(int province);
 
 	[[nodiscard]] std::optional<HoI4::Relations> getRelations(const std::string& withWhom) const;
 	[[nodiscard]] std::optional<date> getTruceUntil(const std::string& withWhom) const;
@@ -312,7 +317,8 @@ class Country
 	void setTrainsMultiplier(float multiplier) { trainsMultiplier = multiplier; }
 
 	[[nodiscard]] const auto& getGlobalEventTargets() const { return globalEventTargets; }
-	[[nodiscard]] bool isProvinceInHomeArea(int provinceId) const { return homeAreaProvinces.contains(provinceId); }
+	[[nodiscard]] const auto& getHomeAreaProvinces() const { return homeAreaProvinces; }
+	[[nodiscard]] bool isProvinceInHomeArea(int provinceId) const { return homeAreaProvinces[0].contains(provinceId); }
 
 	void convertStrategies(const Mappers::CountryMapper& countryMap,
 		 const Vic2::Country& sourceCountry,
@@ -473,7 +479,7 @@ class Country
 
 	std::map<std::string, float> sourceCountryGoods;
 	std::set<std::string> globalEventTargets;
-	std::set<int> homeAreaProvinces;
+	std::vector<std::set<int>> homeAreaProvinces;
 
 	std::vector<std::string> unbuiltCanals;
 

--- a/src/HOI4World/HoI4Country.h
+++ b/src/HOI4World/HoI4Country.h
@@ -153,15 +153,15 @@ class Country
 
 	void addUnbuiltCanal(const std::string& unbuiltCanal) { unbuiltCanals.push_back(unbuiltCanal); }
 
-	void classifyProvincesByAreas(const std::unique_ptr<Maps::MapData>& theMapData,
+	void determineDominionAreas(const std::unique_ptr<Maps::MapData>& theMapData,
 		 const std::map<int, HoI4::State>& allStates,
 		 const std::map<int, int>& provinceToStateIdMap);
-	void addProvincesToHomeArea(int provinceId,
-		 std::set<int>& provincesInArea,
+	void addProvincesToArea(int startingProvince,
+		 std::set<int>& area,
 		 const std::unique_ptr<Maps::MapData>& theMapData,
 		 const std::map<int, HoI4::State>& allStates,
 		 const std::map<int, int>& provinceToStateIdMap);
-	bool isProvinceAssignedToArea(int province);
+	bool isProvinceInDominionArea(int province);
 
 	[[nodiscard]] std::optional<HoI4::Relations> getRelations(const std::string& withWhom) const;
 	[[nodiscard]] std::optional<date> getTruceUntil(const std::string& withWhom) const;
@@ -317,8 +317,8 @@ class Country
 	void setTrainsMultiplier(float multiplier) { trainsMultiplier = multiplier; }
 
 	[[nodiscard]] const auto& getGlobalEventTargets() const { return globalEventTargets; }
-	[[nodiscard]] const auto& getHomeAreaProvinces() const { return homeAreaProvinces; }
-	[[nodiscard]] bool isProvinceInHomeArea(int provinceId) const { return homeAreaProvinces[0].contains(provinceId); }
+	[[nodiscard]] const auto& getDominionAreas() const { return dominionAreas; }
+	[[nodiscard]] bool isProvinceInCapitalArea(int province) const { return dominionAreas[0].contains(province); }
 
 	void convertStrategies(const Mappers::CountryMapper& countryMap,
 		 const Vic2::Country& sourceCountry,
@@ -479,7 +479,7 @@ class Country
 
 	std::map<std::string, float> sourceCountryGoods;
 	std::set<std::string> globalEventTargets;
-	std::vector<std::set<int>> homeAreaProvinces;
+	std::vector<std::set<int>> dominionAreas;
 
 	std::vector<std::string> unbuiltCanals;
 

--- a/src/HOI4World/HoI4Country.h
+++ b/src/HOI4World/HoI4Country.h
@@ -153,7 +153,7 @@ class Country
 
 	void addUnbuiltCanal(const std::string& unbuiltCanal) { unbuiltCanals.push_back(unbuiltCanal); }
 
-	void determineDominionAreas(const std::unique_ptr<Maps::MapData>& theMapData,
+	std::vector<std::set<int>> getDominionAreas(const std::unique_ptr<Maps::MapData>& theMapData,
 		 const std::map<int, HoI4::State>& allStates,
 		 const std::map<int, int>& provinceToStateIdMap);
 	void addProvincesToArea(int startingProvince,
@@ -161,7 +161,11 @@ class Country
 		 const std::unique_ptr<Maps::MapData>& theMapData,
 		 const std::map<int, HoI4::State>& allStates,
 		 const std::map<int, int>& provinceToStateIdMap);
-	bool isProvinceInDominionArea(int province);
+	bool isProvinceInDominionArea(int province, const std::vector<std::set<int>>& dominionAreas);
+	bool isProvinceInCapitalArea(int province, const std::vector<std::set<int>>& dominionAreas) const
+	{
+		return dominionAreas[0].contains(province);
+	}
 
 	[[nodiscard]] std::optional<HoI4::Relations> getRelations(const std::string& withWhom) const;
 	[[nodiscard]] std::optional<date> getTruceUntil(const std::string& withWhom) const;
@@ -317,8 +321,6 @@ class Country
 	void setTrainsMultiplier(float multiplier) { trainsMultiplier = multiplier; }
 
 	[[nodiscard]] const auto& getGlobalEventTargets() const { return globalEventTargets; }
-	[[nodiscard]] const auto& getDominionAreas() const { return dominionAreas; }
-	[[nodiscard]] bool isProvinceInCapitalArea(int province) const { return dominionAreas[0].contains(province); }
 
 	void convertStrategies(const Mappers::CountryMapper& countryMap,
 		 const Vic2::Country& sourceCountry,
@@ -479,7 +481,6 @@ class Country
 
 	std::map<std::string, float> sourceCountryGoods;
 	std::set<std::string> globalEventTargets;
-	std::vector<std::set<int>> dominionAreas;
 
 	std::vector<std::string> unbuiltCanals;
 

--- a/src/HOI4World/HoI4World.cpp
+++ b/src/HOI4World/HoI4World.cpp
@@ -606,14 +606,14 @@ void HoI4::World::addDominions(Mappers::CountryMapper::Factory& countryMapperFac
 			Log(LogLevel::Debug) << "Province " << *capital << " is not defined in Configurables/regions.txt";
 			continue;
 		}
-		country->determineDominionAreas(theMapData, states->getStates(), states->getProvinceToStateIDMap());
 
-		for (const auto& area: country->getDominionAreas())
+		const auto& areas = country->getDominionAreas(theMapData, states->getStates(), states->getProvinceToStateIDMap());
+		for (const auto& area: areas)
 		{
 			std::set<int> areaStates;
 			for (const auto& province: area)
 			{
-				if (country->isProvinceInCapitalArea(province))
+				if (country->isProvinceInCapitalArea(province, areas))
 				{
 					continue;
 				}
@@ -745,13 +745,15 @@ std::string HoI4::World::getBestRegion(const std::set<int>& area, const std::str
 	{
 		sortedRegions.push_back(region);
 	}
-	std::sort(sortedRegions.begin(), sortedRegions.end(), [](std::pair<std::string, int>& a, std::pair<std::string, int>& b) {
-		return a.second > b.second;
-	});
+	std::sort(sortedRegions.begin(),
+		 sortedRegions.end(),
+		 [](std::pair<std::string, int>& a, std::pair<std::string, int>& b) {
+			 return a.second > b.second;
+		 });
 	for (const auto& [region, provinces]: sortedRegions)
 	{
 		if (const auto& dominionItr = dominions.find(std::make_pair(ownerTag, region));
-			dominionItr != dominions.end() && provinces / area.size() < minProvincesInRegion)
+			 dominionItr != dominions.end() && provinces / area.size() < minProvincesInRegion)
 		{
 			continue;
 		}

--- a/src/HOI4World/HoI4World.cpp
+++ b/src/HOI4World/HoI4World.cpp
@@ -649,7 +649,7 @@ void HoI4::World::addDominions(Mappers::CountryMapper::Factory& countryMapperFac
 				continue;
 			}
 
-			auto dominion = getDominion(tag, country, area, *theRegions, *graphicsMapper, *names);
+			auto dominion = getDominion(country, area, *graphicsMapper, *names);
 
 			for (const auto& stateInArea: areaStates)
 			{
@@ -709,21 +709,20 @@ void HoI4::World::addDominions(Mappers::CountryMapper::Factory& countryMapperFac
 }
 
 
-std::shared_ptr<HoI4::Country> HoI4::World::getDominion(const std::string& ownerTag,
-	 const std::shared_ptr<Country>& owner,
+std::shared_ptr<HoI4::Country> HoI4::World::getDominion(const std::shared_ptr<Country>& owner,
 	 const std::set<int>& area,
-	 const Regions& regions,
 	 Mappers::GraphicsMapper& graphicsMapper,
 	 Names& names)
 {
-	const auto& region = getBestRegion(area, ownerTag);
-	if (const auto& dominionItr = dominions.find(std::make_pair(ownerTag, region)); dominionItr != dominions.end())
+	const auto& region = getBestRegion(area, owner->getTag());
+	if (const auto& dominionItr = dominions.find(std::make_pair(owner->getTag(), region));
+		 dominionItr != dominions.end())
 	{
 		return dominionItr->second;
 	}
 
-	auto dominion = std::make_shared<Country>(owner, region, regions, graphicsMapper, names);
-	dominions.emplace(std::make_pair(ownerTag, region), dominion);
+	auto dominion = std::make_shared<Country>(owner, region, *theRegions, graphicsMapper, names);
+	dominions.emplace(std::make_pair(owner->getTag(), region), dominion);
 
 	return dominion;
 }
@@ -833,7 +832,7 @@ void HoI4::World::addUnrecognizedNations(Mappers::CountryMapper::Factory& countr
 			continue;
 		}
 
-		auto nation = getUnrecognizedNation(*stateRegion, *theRegions, *graphicsMapper, *names);
+		auto nation = getUnrecognizedNation(*stateRegion, *graphicsMapper, *names);
 		nation->addCoreState(stateId);
 		state.smashNavalBases();
 	}
@@ -900,7 +899,6 @@ void HoI4::World::addUnrecognizedNations(Mappers::CountryMapper::Factory& countr
 
 
 std::shared_ptr<HoI4::Country> HoI4::World::getUnrecognizedNation(const std::string& region,
-	 const Regions& regions,
 	 Mappers::GraphicsMapper& graphicsMapper,
 	 Names& names)
 {
@@ -909,7 +907,7 @@ std::shared_ptr<HoI4::Country> HoI4::World::getUnrecognizedNation(const std::str
 		return unrecognizedItr->second;
 	}
 
-	auto nation = std::make_shared<Country>(region, regions, graphicsMapper, names);
+	auto nation = std::make_shared<Country>(region, *theRegions, graphicsMapper, names);
 	unrecognizedNations.emplace(region, nation);
 
 	return nation;

--- a/src/HOI4World/HoI4World.cpp
+++ b/src/HOI4World/HoI4World.cpp
@@ -172,7 +172,6 @@ HoI4::World::World(const Vic2::World& sourceWorld,
 	hoi4Localisations->addStateLocalisations(*states, vic2Localisations, provinceMapper, theConfiguration);
 	Log(LogLevel::Progress) << "48%";
 	convertIndustry(theConfiguration);
-	addProvincesToDominionAreas();
 	convertDiplomacy(sourceWorld);
 	convertWars(sourceWorld, provinceMapper);
 	addDominions(countryMapperFactory);
@@ -582,7 +581,7 @@ void HoI4::World::addDominions(Mappers::CountryMapper::Factory& countryMapperFac
 	Log(LogLevel::Info) << "Adding dominions";
 	auto& modifiableStates = states->getModifiableStates();
 
-	for (auto& [tag, country]: countries)
+	for (auto& [tag, country]: landedCountries)
 	{
 		if (tag == "UCV")
 		{
@@ -607,6 +606,7 @@ void HoI4::World::addDominions(Mappers::CountryMapper::Factory& countryMapperFac
 			Log(LogLevel::Debug) << "Province " << *capital << " is not defined in Configurables/regions.txt";
 			continue;
 		}
+		country->determineDominionAreas(theMapData, states->getStates(), states->getProvinceToStateIDMap());
 
 		for (const auto& area: country->getDominionAreas())
 		{
@@ -1701,20 +1701,6 @@ std::set<std::string> HoI4::World::getSouthAsianCountries() const
 	}
 
 	return southAsianCountries;
-}
-
-
-void HoI4::World::addProvincesToDominionAreas()
-{
-	Log(LogLevel::Info) << "\tAdding provinces to dominion areas";
-	for (const auto& country: landedCountries | std::views::values)
-	{
-		if (!country->getCapitalProvince())
-		{
-			continue;
-		}
-		country->determineDominionAreas(theMapData, states->getStates(), states->getProvinceToStateIDMap());
-	}
 }
 
 

--- a/src/HOI4World/HoI4World.h
+++ b/src/HOI4World/HoI4World.h
@@ -209,15 +209,12 @@ class World: commonItems::parser
 
 	std::set<std::string> getSouthAsianCountries() const;
 
-	std::shared_ptr<Country> getDominion(const std::string& ownerTag,
-		 const std::shared_ptr<Country>& owner,
+	std::shared_ptr<Country> getDominion(const std::shared_ptr<Country>& owner,
 		 const std::set<int>& area,
-		 const Regions& regions,
 		 Mappers::GraphicsMapper& graphicsMapper,
 		 Names& names);
 	std::string getBestRegion(const std::set<int>& area, const std::string& ownerTag);
 	std::shared_ptr<Country> getUnrecognizedNation(const std::string& region,
-		 const Regions& regions,
 		 Mappers::GraphicsMapper& graphicsMapper,
 		 Names& names);
 

--- a/src/HOI4World/HoI4World.h
+++ b/src/HOI4World/HoI4World.h
@@ -222,7 +222,7 @@ class World: commonItems::parser
 		 Names& names);
 
 	bool dominionIsReleasable(const Country& dominion);
-	void addProvincesToHomeAreas();
+	void addProvincesToDominionAreas();
 
 	void recordUnbuiltCanals(const Vic2::World& sourceWorld);
 

--- a/src/HOI4World/HoI4World.h
+++ b/src/HOI4World/HoI4World.h
@@ -211,10 +211,11 @@ class World: commonItems::parser
 
 	std::shared_ptr<Country> getDominion(const std::string& ownerTag,
 		 const std::shared_ptr<Country>& owner,
-		 const std::string& region,
+		 const std::set<int>& area,
 		 const Regions& regions,
 		 Mappers::GraphicsMapper& graphicsMapper,
 		 Names& names);
+	std::string getBestRegion(const std::set<int>& area, const std::string& ownerTag);
 	std::shared_ptr<Country> getUnrecognizedNation(const std::string& region,
 		 const Regions& regions,
 		 Mappers::GraphicsMapper& graphicsMapper,

--- a/src/HOI4World/HoI4World.h
+++ b/src/HOI4World/HoI4World.h
@@ -222,7 +222,6 @@ class World: commonItems::parser
 		 Names& names);
 
 	bool dominionIsReleasable(const Country& dominion);
-	void addProvincesToDominionAreas();
 
 	void recordUnbuiltCanals(const Vic2::World& sourceWorld);
 


### PR DESCRIPTION
Partitions countries into areas of contiguous provinces. For each area, an attempt will be made to create a new dominion, with one exception - if at least 60% of area provinces belong to a particular region, the area will be assigned to that region. The usual limits regarding land connection to capital, core on state, less than 2 states in a dominion etc. still apply.