### PR TITLE
Hotfix MapData input pointing to wrong place

### DIFF
--- a/src/HOI4World/HoI4World.cpp
+++ b/src/HOI4World/HoI4World.cpp
@@ -91,7 +91,6 @@ void checkAllProvincesAssignedToRegion(const HoI4::Regions& theRegions,
 
 HoI4::World::World(const Vic2::World& sourceWorld,
 	 const Mappers::ProvinceMapper& provinceMapper,
-	 const commonItems::ModFilesystem& mod_filesystem,
 	 const Configuration& theConfiguration):
 	 theIdeas(std::make_unique<HoI4::Ideas>()),
 	 theDecisions(make_unique<HoI4::decisions>(theConfiguration)), peaces(make_unique<HoI4::AiPeaces>()),
@@ -112,7 +111,7 @@ HoI4::World::World(const Vic2::World& sourceWorld,
 	Character::Factory characterFactory;
 	provinceDefinitions =
 		 std::make_unique<Maps::ProvinceDefinitions>(importProvinceDefinitions(theConfiguration.getHoI4Path()));
-	theMapData = std::make_unique<Maps::MapData>(*provinceDefinitions, mod_filesystem);
+	theMapData = std::make_unique<Maps::MapData>(*provinceDefinitions, theConfiguration.getHoI4Path());
 	const auto theProvinces = importProvinces(theConfiguration);
 	theCoastalProvinces.init(*theMapData, theProvinces);
 	strategicRegions = StrategicRegions::Factory().importStrategicRegions(theConfiguration);

--- a/src/HOI4World/HoI4World.h
+++ b/src/HOI4World/HoI4World.h
@@ -73,7 +73,6 @@ class World: commonItems::parser
   public:
 	explicit World(const Vic2::World& sourceWorld,
 		 const Mappers::ProvinceMapper& provinceMapper,
-		 const commonItems::ModFilesystem& mod_filesystem,
 		 const Configuration& theConfiguration);
 	~World() = default;
 

--- a/src/Maps/MapData.cpp
+++ b/src/Maps/MapData.cpp
@@ -115,7 +115,7 @@ void Maps::MapData::ImportProvinces(const std::string& path)
 	auto full_path = path;
 	if (path.find("/map/provinces.bmp") == std::string::npos)
 		full_path = path + "/map/provinces.bmp";
-	
+
 	bitmap_image province_map(full_path);
 	if (!province_map)
 	{

--- a/src/Maps/MapData.cpp
+++ b/src/Maps/MapData.cpp
@@ -92,6 +92,13 @@ Maps::MapData::MapData(const ProvinceDefinitions& province_definitions,
 	ImportAdjacencies(mod_filesystem);
 }
 
+Maps::MapData::MapData(const ProvinceDefinitions& province_definitions, const std::string& path):
+	 province_definitions_(province_definitions)
+{
+	ImportProvinces(path);
+	ImportAdjacencies(path);
+}
+
 
 void Maps::MapData::ImportProvinces(const commonItems::ModFilesystem& mod_filesystem)
 {
@@ -100,10 +107,19 @@ void Maps::MapData::ImportProvinces(const commonItems::ModFilesystem& mod_filesy
 	{
 		throw std::runtime_error("Could not find /map/provinces.bmp");
 	}
-	bitmap_image province_map(*path);
+	ImportProvinces(*path);
+}
+
+void Maps::MapData::ImportProvinces(const std::string& path)
+{
+	auto full_path = path;
+	if (path.find("/map/provinces.bmp") == std::string::npos)
+		full_path = path + "/map/provinces.bmp";
+	
+	bitmap_image province_map(full_path);
 	if (!province_map)
 	{
-		throw std::runtime_error("Could not open " + *path + "/map/provinces.bmp");
+		throw std::runtime_error("Could not open " + full_path + "/map/provinces.bmp");
 	}
 
 	const int height = static_cast<int>(province_map.height());
@@ -235,11 +251,19 @@ void Maps::MapData::ImportAdjacencies(const commonItems::ModFilesystem& mod_file
 	{
 		throw std::runtime_error("Could not find /map/adjacencies.csv");
 	}
+	ImportAdjacencies(*path);
+}
 
-	std::ifstream adjacencies_file(*path);
+void Maps::MapData::ImportAdjacencies(const std::string& path)
+{
+	auto full_path = path;
+	if (path.find("/map/adjacencies.csv") == std::string::npos)
+		full_path = path + "/map/adjacencies.csv";
+
+	std::ifstream adjacencies_file(full_path);
 	if (!adjacencies_file.is_open())
 	{
-		throw std::runtime_error("Could not open " + *path);
+		throw std::runtime_error("Could not open " + full_path);
 	}
 
 	while (!adjacencies_file.eof())

--- a/src/Maps/MapData.h
+++ b/src/Maps/MapData.h
@@ -24,6 +24,7 @@ class MapData
 {
   public:
 	MapData(const ProvinceDefinitions& province_definitions, const commonItems::ModFilesystem& mod_filesystem);
+	MapData(const ProvinceDefinitions& province_definitions, const std::string& path);
 
 	[[nodiscard]] std::set<int> GetNeighbors(int province) const;
 	[[nodiscard]] std::optional<Point> GetSpecifiedBorderCenter(int main_province, int neighbor) const;
@@ -34,6 +35,7 @@ class MapData
 
   private:
 	void ImportProvinces(const commonItems::ModFilesystem& mod_filesystem);
+	void ImportProvinces(const std::string& path);
 	void HandleNeighbor(const commonItems::Color& center_color,
 		 const commonItems::Color& other_color,
 		 const Point& position);
@@ -42,6 +44,7 @@ class MapData
 	void AddPointToBorder(int main_province, int neighbor_province, Point position);
 
 	void ImportAdjacencies(const commonItems::ModFilesystem& mod_filesystem);
+	void ImportAdjacencies(const std::string& path);
 
 	std::map<int, std::set<int>> province_neighbors_;
 	std::map<int, BordersWith> borders_;

--- a/src/Vic2toHOI4Converter.cpp
+++ b/src/Vic2toHOI4Converter.cpp
@@ -22,7 +22,7 @@ void ConvertV2ToHoI4(const commonItems::ConverterVersion& converterVersion)
 	const commonItems::ModFilesystem vic2_filesystem(the_configuration->getVic2Path(), the_configuration->getVic2Mods());
 	const auto sourceWorld = Vic2::World::Factory(vic2_filesystem, the_configuration->getPercentOfCommanders())
 										  .importWorld(*the_configuration, *provinceMapper, vic2_filesystem);
-	const HoI4::World destWorld(*sourceWorld, *provinceMapper, vic2_filesystem, *the_configuration);
+	const HoI4::World destWorld(*sourceWorld, *provinceMapper, *the_configuration);
 
 	output(destWorld,
 		 the_configuration->getOutputName(),


### PR DESCRIPTION
Undo passing of vic mod_filesystem into hoi4::world and overload MapData fxns. Wrote them in terms of each other.